### PR TITLE
use Java/1.8 wrapper for SNAP-ESA and SNAP-ESA-python + take into account that `$JAVA_TOOL_OPTIONS` may not be defined + add modtclfooter equivalent to modluafooter

### DIFF
--- a/easybuild/easyconfigs/s/SNAP-ESA-python/SNAP-ESA-python-8.0-GCCcore-10.2.0-Java-1.8-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/s/SNAP-ESA-python/SNAP-ESA-python-8.0-GCCcore-10.2.0-Java-1.8-Python-2.7.18.eb
@@ -43,6 +43,10 @@ modextrapaths = {'PYTHONPATH': [local_pysite]}
 local_javaopts = " -Dsnap.pythonExecutable=python"
 local_javaopts += " -Dsnap.pythonModuleDir=%s" % local_pyinstalldir
 
-modluafooter = 'setenv("JAVA_TOOL_OPTIONS", os.getenv("JAVA_TOOL_OPTIONS").."%s")' % local_javaopts
+# update $JAVA_TOOL_OPTIONS when module is loaded, use empty string as default value if $JAVA_TOOL_OPTIONS is not set
+modluafooter = 'setenv("JAVA_TOOL_OPTIONS", (os.getenv("JAVA_TOOL_OPTIONS") or "") .. "%s")' % local_javaopts
+# likewise, but when using Tcl as module syntax
+local_tcl_JAVA_TOOL_OPTIONS = '[expr {[info exists ::env(JAVA_TOOL_OPTIONS)] ? $::env(JAVA_TOOL_OPTIONS) : ""}]'
+modtclfooter = 'setenv JAVA_TOOL_OPTIONS [concat %s "%s"]' % (local_tcl_JAVA_TOOL_OPTIONS, local_javaopts)
 
 moduleclass = 'geo'

--- a/easybuild/easyconfigs/s/SNAP-ESA-python/SNAP-ESA-python-8.0-GCCcore-10.2.0-Java-1.8-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/s/SNAP-ESA-python/SNAP-ESA-python-8.0-GCCcore-10.2.0-Java-1.8-Python-2.7.18.eb
@@ -2,7 +2,7 @@ easyblock = 'Bundle'
 
 name = 'SNAP-ESA-python'
 version = '8.0'
-local_javasuffix = '-Java-%(javaver)s-OpenJDK'
+local_javasuffix = '-Java-%(javaver)s'
 versionsuffix = local_javasuffix + '-Python-%(pyver)s'
 
 homepage = 'https://step.esa.int/main/toolboxes/snap/'
@@ -11,7 +11,7 @@ description = "Python interface to the Sentinel Application Platform (SNAP) API"
 toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
 
 dependencies = [
-    ('Java', '1.8.0_292', '-OpenJDK', SYSTEM),
+    ('Java', '1.8', '', SYSTEM),
     ('SNAP-ESA', version, local_javasuffix, SYSTEM),
     ('Python', '2.7.18'),
 ]

--- a/easybuild/easyconfigs/s/SNAP-ESA/SNAP-ESA-8.0-Java-1.8.eb
+++ b/easybuild/easyconfigs/s/SNAP-ESA/SNAP-ESA-8.0-Java-1.8.eb
@@ -31,7 +31,7 @@ checksums = [
 ]
 
 # The installation is executed with the bundled JRE 1.8.0_242 (Zulu)
-# at runtime we switch it to AdoptOpenJDK, which is known to be more reliable for SNAP-ESA
+# At runtime we switch to an external JDK (SNAP developers recommend any OpenJDK distribution)
 dependencies = [
     ('Java', '1.8'),
 ]

--- a/easybuild/easyconfigs/s/SNAP-ESA/SNAP-ESA-8.0-Java-1.8.eb
+++ b/easybuild/easyconfigs/s/SNAP-ESA/SNAP-ESA-8.0-Java-1.8.eb
@@ -2,7 +2,7 @@ easyblock = 'Binary'
 
 name = 'SNAP-ESA'
 version = '8.0'
-versionsuffix = '-Java-%(javaver)s-OpenJDK'
+versionsuffix = '-Java-%(javaver)s'
 
 homepage = 'https://step.esa.int/main/toolboxes/snap/'
 description = """
@@ -33,7 +33,7 @@ checksums = [
 # The installation is executed with the bundled JRE 1.8.0_242 (Zulu)
 # at runtime we switch it to AdoptOpenJDK, which is known to be more reliable for SNAP-ESA
 dependencies = [
-    ('Java', '1.8.0_292', '-OpenJDK'),
+    ('Java', '1.8'),
 ]
 
 install_cmd = "INSTALL4J_TEMP='%(builddir)s' "


### PR DESCRIPTION
@lexming for https://github.com/easybuilders/easybuild-easyconfigs/pull/13198